### PR TITLE
fix: restore deleted line service method

### DIFF
--- a/sound_detect/line_service.py
+++ b/sound_detect/line_service.py
@@ -38,6 +38,42 @@ class LineMessagingService:
         
         return self._send_request(url, payload)
     
+    def _send_request(self, url: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Send HTTP request to LINE API
+        
+        Args:
+            url: API endpoint URL
+            payload: Request payload
+            
+        Returns:
+            Dict containing response data or error information
+        """
+        try:
+            response = requests.post(url, headers=self.headers, json=payload)
+            
+            if response.status_code == 200:
+                return {
+                    "success": True,
+                    "status_code": response.status_code,
+                    "data": response.json() if response.content else None
+                }
+            else:
+                error_data = response.json() if response.content else {}
+                return {
+                    "success": False,
+                    "status_code": response.status_code,
+                    "error": error_data.get("message", "Unknown error"),
+                    "details": error_data.get("details", [])
+                }
+                
+        except requests.exceptions.RequestException as e:
+            return {
+                "success": False,
+                "error": str(e),
+                "status_code": None
+            }
+    
 
 def create_line_service(channel_access_token: str) -> LineMessagingService:
     """


### PR DESCRIPTION
Restore the missing `_send_request` method in LineMessagingService class because it was accidentally deleted in the [previous change](https://github.com/hitochan777/fuzai/commit/3a2ad34c23bd07c4609a75cb0ceeb36ccbfac266#diff-9b2a1da72a572b9a5f00b41bfbc546c1b6c437246b35d5f4a41baa72919d8b6fL326)