### PR TITLE
Change default notifier to Slack

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,7 @@ def create_notifier_from_env():
     Raises:
         ValueError: If required environment variables are missing or notifier type is unsupported
     """
-    notifier_type = os.environ.get("NOTIFIER_TYPE", "line").lower()
+    notifier_type = os.environ.get("NOTIFIER_TYPE", "slack").lower()
 
     if notifier_type == "slack":
         slack_token = os.environ.get("SLACK_BOT_TOKEN")


### PR DESCRIPTION
## Summary
- Changed the default `NOTIFIER_TYPE` from `"line"` to `"slack"` in `app.py`
- This makes Slack the default notification service when the `NOTIFIER_TYPE` environment variable is not explicitly set
- Users can still override by setting `NOTIFIER_TYPE=line` or `NOTIFIER_TYPE=email`

🤖 Generated with [Claude Code](https://claude.com/claude-code)